### PR TITLE
Call `DotMap` with square brackets

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift-no-dbt/destination_redshift_no_dbt/destination.py
+++ b/airbyte-integrations/connectors/destination-redshift-no-dbt/destination_redshift_no_dbt/destination.py
@@ -121,13 +121,14 @@ class DestinationRedshiftNoDbt(Destination):
 
                         children_records = []
                         for parent_item in parents:
-                            children = getattr(parent_item, method)
+                            children = parent_item.get(method)
                             if not isinstance(children, list):
                                 children = [children]
 
                             for child_item in children:
                                 if child_item and final_table.references and method == node[-1]:
                                     child_item[final_table.reference_key.name] = parent_item[AIRBYTE_ID_NAME]
+
 
                                 children_records.append(child_item)
 

--- a/airbyte-integrations/connectors/destination-redshift-no-dbt/destination_redshift_no_dbt/jsonschema_to_tables.py
+++ b/airbyte-integrations/connectors/destination-redshift-no-dbt/destination_redshift_no_dbt/jsonschema_to_tables.py
@@ -30,6 +30,7 @@ class JsonToTables:
 
         for property_key, property_value in properties.items():
             item_type = property_value.get("type")
+            item_type = [item_type] if not isinstance(item_type, list) else item_type
             if not set(item_type).intersection({"object", "array"}):
                 data_type = DataTypeConverter.convert(property_value["type"], property_value.get("format"), property_value.get("maxLength"))
                 table.fields.append(Field(name=property_key, data_type=data_type))


### PR DESCRIPTION
To avoid conflicts with builtin methods in `DotMap` such as `items` method